### PR TITLE
Fix baseUrl support

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,7 +3,7 @@
 pushd "$GITHUB_WORKSPACE/$HUGO_ROOT"
 
 npm ci
-npx hugo serve --baseUrl "http://localhost:1313" --contentDir "$GITHUB_WORKSPACE/$HUGO_CONTENT_DIR" --config "$GITHUB_WORKSPACE/$HUGO_CONFIG" &
+npx hugo serve --baseURL "http://localhost:1313" --contentDir "$GITHUB_WORKSPACE/$HUGO_CONTENT_DIR" --config "$GITHUB_WORKSPACE/$HUGO_CONFIG" &
 HUGO_PID=$!
 
 popd


### PR DESCRIPTION
HI folks! I fixed this in my fork and wondered if you might need it as well.

This PR fixes the hugo command formatting for baseURL. When you run the action as-is with newer versions of Hugo (I tried with 0.115.3), Hugo returns an error because the baseURL flag isn't properly formatted. 